### PR TITLE
Add Meetei style

### DIFF
--- a/index.html
+++ b/index.html
@@ -1441,6 +1441,23 @@ symbols: '\D66' '\D67' '\D68' '\D69' '\D6A' '\D6B' '\D6C' '\D6D' '\D6E' '\D6F';<
 
 
 
+<section id="meetei-styles">
+<h2>Meetei</h2>
+
+<div class="counterstyle">
+<code><bdo dir="ltr">
+@counter-style <dfn id="meetei"><a href="#meetei">meetei</a></dfn> {<br/>
+system: numeric;<br/>
+symbols: '\ABF0' '\ABF1' '\ABF2' '\ABF3' '\ABF4' '\ABF5' '\ABF6' '\ABF7' '\ABF8' '\ABF9';<br/>
+/* symbols: '&#44016;' '&#44017;' '&#44018;' '&#44019;' '&#44020;' '&#44021;' '&#44022;' '&#44023;' '&#44024;' '&#44025;'; */<br/>
+suffix: ') ';<br/>
+}
+</bdo></code></div>
+
+</section>
+
+
+
 <section id="mongolian-styles">
 <h2>Mongolian</h2>
 


### PR DESCRIPTION
Meetei, also known as Meitei and Meetei Mayek, is a writing system used by the Manipuri language in Eastern India. It has its own set of digits, and they are used on books and websites for numbering lists.

Here are examples of using such lists in a printed book:
![photo_2020-09-18_19-54-10](https://user-images.githubusercontent.com/346271/93624354-e81a7b80-f9e8-11ea-92cf-f9e0c79fea65.jpg)
![photo_2020-09-18_19-54-02](https://user-images.githubusercontent.com/346271/93624368-eb156c00-f9e8-11ea-803d-ffa492fb62ab.jpg)
![photo_2020-09-18_19-53-41](https://user-images.githubusercontent.com/346271/93624370-ebae0280-f9e8-11ea-9124-243216da79e8.jpg)
![photo_2020-09-18_19-53-30](https://user-images.githubusercontent.com/346271/93624374-ecdf2f80-f9e8-11ea-9f8d-07a345b326d6.jpg)

Book information:
Author: Angomcha Chingsubam Laicha
Title: Wachet Pathup 
Published: 28 May 2015

Online, this is also used in the Manipuri Wikipedia, for example here:
https://incubator.wikimedia.org/w/index.php?oldid=4589559

The information and the examples were provided by Yaibeelen Mangang, a volunteer editor in the Manipuri Wikipedia.