### PR TITLE
Various updates:

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 <p>This document describes counter styles used by various cultures around the world and can be used as a reference for those wishing to define user-defined counter styles for CSS. The content of this document was originally part of the CSS Lists and Counters specification, but is now published as a standalone document by the W3C Internationalization Working Group. It is expected that the document will be updated from time to time to include new information.</p>
 </div>
 <section id="abstract">
-<p>This document provides ready-made definitions for counter styles and covers the needs of various cultures around the world. The code snippets provided in the document can be included in style declarations by simply copying and pasting, or they can be use as a starting point and modified as desired.</p>
+<p>This document provides ready-made definitions for counter styles and covers the needs of a range of cultures around the world. The code snippets provided in the document can be included in style declarations by simply copying and pasting, or they can be use as a starting point and modified as desired.</p>
 </section>
     
 <section id="intro">
@@ -58,22 +58,98 @@ ol { list-style-type: arabic-indic; }</pre>
 </div>
 <p>The <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification includes a number of predefined counter-styles for which browsers are expected to implement built-in support. The definitions of those styles are also included here, for ease of reference, and identified as such by a note.</p>
 <p>We try to only include in this document counter styles that are in regular use in the wild, and we are particularly interested in supporting the needs of people who use non-Latin scripts. You may find more experimental or new templates on other sites, such as that <a href="https://github.com/Crissov/css-counters">provided by Christoph Päper</a>.</p>
+
+
+
+
+
+<section id="affixes">
+<h3>Adapting prefixes &amp; suffixes</h3>
+
+<p>The likelihood that you will need to customise the basic counter symbols in the styles provided here is low. However, there is a much higher likelihood that you will want to vary the affixes (prefix and/or suffix) associated with  counters. For example, counters used for numbering headings may look better as just the bare counter, whereas in lists the counter may be following by a period+space,  be surrounded by parentheses, or be followed by a script-specific delimiter, etc. In fact, different strategies  may be used on the same page, depending on the level of nesting or the context in which the list is used.</p>
+<p>For the styles shown here we apply a common default. (Often, none is specified, which will result in a period+space suffix.) If you want a different affix you should make the appropriate change. Code for some common alternatives is given in the panel just below.</p>
+
+<div class="example" id="standard_alt_prefix_suffix">
+<p>Space-only suffixes need to be explicitly defined as follows:</p>
+<pre translate="no"><bdo dir="ltr">suffix: ' ';</bdo></pre>
+
+<p>Counters in parentheses need to have both prefix and suffix defined:</p>
+<pre translate="no"><bdo dir="ltr">prefix: '(';
+suffix: ') ';</bdo></pre>
+</div>
+
+<p>Notes are used to describe alternative affixes for a given style, and where they involve a non-ASCII character or some other special arrangement, suggested code is provided.</p>
+<div class="example" id="native_alt_prefix_suffix">
+<p>For example, Myanmar may use <span class="codepoint" translate="no"><span lang="my">&#x104B;</span> [<span class="uname">U+104B MYANMAR SIGN SECTION</span>]</span> as a suffix, so the Myanmar section includes:</p>
+<pre translate="no"><bdo dir="ltr">suffix: '။ ';</bdo></pre>
+</div>
+
+<p>If you want to provide multiple alternative affix declarations for a given counter style, you will find it most effective to  add another style using the standard extension mechanism.</p>
+
+<div class="example" id="extensions">
+<p>For example, the following defines two styles for Myanmar that differ only in the prefix/suffix used. Either style can be used for a given list just by specifying the appropriate name.</p>
+<pre translate="no">
+<bdo dir="ltr">
+@counter-style myanmar {
+system: numeric;
+symbols: '၀' '၁' '၂' '၃' '၄' '၅' '၆' '၇' '၈' '၉';
+prefix: '(';
+suffix: ') ';
+}
+
+@counter-style myanmar-section {
+system: extends myanmar;
+prefix: '';
+suffix: "။ ";
+}
+
+ol { list-style-type: myanmar; }
+#toc ol { list-style-type: myanmar-section; }
+</bdo>
+</pre>
+</div>
 </section>
 
+
+
+
+
 <section id="tips">
-<h2>Things to remember</h2>
+<h3>Things to remember</h3>
 
 <ol>
 <li>
-<p>At the time of writing, the CSS Counter Styles Level 3 specification is still in the Candidate Recommendation phase, and custom counter styles are not widely supported in browsers. Hopefully this will change soon, although browser implementers implement things sooner if they receive requests from users. See a <a href="https://w3c.github.io/i18n-tests/results/counter-styles">set of basic tests</a> to find which browsers support this feature. On browsers that don't support custom counter styles, the counter styles will fall back to the default.</p>
+<p>At the time of writing, the CSS Counter Styles Level 3 specification is still in the Candidate Recommendation phase. Custom counter styles are not  yet <a href="https://github.com/w3c/iip/issues/93">supported in all browsers</a>.  See a <a href="https://w3c.github.io/i18n-tests/results/counter-styles">set of basic tests</a> to find which browsers support this feature. On browsers that don't support custom counter styles, the counter styles will fall back to the default.</p>
 <p>Many of the styles described here are already supported by name in browsers. See <a href="https://w3c.github.io/i18n-tests/results/custom-counter-styles">the tests for a list of what international styles are supported</a> natively by which browsers.</p>
 </li>
 <li>
-  <p>You can call these styles or the ones you invent yourself by whatever name you prefer. For example, if you prefer to call the <code class="kw" translate="no">persian</code> counter style <code class="kw" translate="no">extended-arabic</code>, you can just change the name of the counter style. Bear in mind, however, that a counter style called <code class="kw" translate="no">persian</code> is likely to be more widely supported at the moment than a custom style called <code class="kw" translate="no">extended-arabic</code> (see the tests) because it has native support in most major browsers, so using standard names can sometimes be beneficial.</p></li>
-<li><p>The Internationalization Working Group expects this document to be updated from time to time as new information or corrections are added. If you wish to propose new information to be included here, please <a href="https://github.com/w3c/predefined-counter-styles/issues">raise an issue in github</a> (preferred) or write to www-international@w3.org.</p>
+  <p>You can call these styles or the ones you invent yourself by whatever name you prefer. For example, if you prefer to call the <code class="kw" translate="no">persian</code> counter style <code class="kw" translate="no">extended-arabic</code>, you can just change the name of the counter style. Bear in mind, however, that a counter style called <code class="kw" translate="no">persian</code> may be supported by browsers that don't support <code class="kw" translate="no">@counter-style</code>, so using standard names can sometimes be beneficial.</p></li>
+<li><p>The Internationalization Working Group expects this document to be updated from time to time as new information or corrections are added. If you wish to propose new information to be included here, please <a href="https://github.com/w3c/predefined-counter-styles/issues">raise an issue in github</a>.</p>
 <p>However, before submitting a counter-style template for inclusion, please gather evidence that is actually in use in the wild. For example, it is easy to conceive different alphabetic lists that correspond to various European languages, but we haven't yet seen good evidence that such lists are used widely, and so they are not included here. You should also provide a counter style definition for a template you'd like to see included.</p></li>
 </ol>
 </section>
+</section>
+
+
+
+
+
+
+<section id="adlam-styles">
+<h2>Adlam</h2>
+<div class="counterstyle">
+<code><bdo dir="ltr">
+@counter-style <dfn id="adlam"><a href="#arabic-indic">adlam</a></dfn> {
+system: numeric;
+symbols: '\01E950' '\01E951' '\01E952' '\01E953' '\01E954' '\01E955' '\01E956' '\01E957' '\01E958' '\01E959';
+/* symbols: '&#x1E950;' '&#x1E951;' '&#x1E952;' '&#x1E953;' '&#x1E954;' '&#x1E955;' '&#x1E956;' '&#x1E957;' '&#x1E958;' '&#x1E959;'; */
+}
+</bdo></code></div>
+</section>
+
+
+
+
 
 
 
@@ -133,7 +209,7 @@ symbols: '\627' '\628' '\67E' '\62A' '\62B' '\62C' '\686' '\62D' '\62E' '\62F' '
 }
 </code></div>
 
-<p class="note">The <code class="kw" translate="no">arabic-indic</code>, and <code class="kw" translate="no">persian</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">The <code class="kw" translate="no">arabic-indic</code>, and <code class="kw" translate="no">persian</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">arabic-indic </a></code>and <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">persian</a></code> styles.</p>
 <p class="note">Note that HEH+ZWJ are used together in lists of this kind to distinguish the heh from the number 5. The symbols are listed in logical order where escapes are used and also in the underlying code when they are represented as characters (so the code should copy-paste correctly). When reading the displayed list of symbols as arabic characters, however, you should read them  RTL.  (In previous versions of the document a <code class="kw" translate="no">bdo</code> element was used to display everything LTR, but this interfered with the display of the HEH, which is followed by a ZWJ and should appear to join to the left.)</p>
 <div class="note">
   <table id="arabic_comp">
@@ -387,7 +463,7 @@ additive-symbols: 9000 '\554', 8000 '\553', 7000 '\552', 6000 '\551', 5000 '\550
 /* additive-symbols: 9000 '&#1364;', 8000 '&#1363;', 7000 '&#1362;', 6000 '&#1361;', 5000 '&#1360;', 4000 '&#1359;', 3000 '&#1358;', 2000 '&#1357;', 1000 '&#1356;', 900 '&#1355;', 800 '&#1354;', 700 '&#1353;', 600 '&#1352;', 500 '&#1351;', 400 '&#1350;', 300 '&#1349;', 200 '&#1348;', 100 '&#1347;', 90 '&#1346;', 80 '&#1345;', 70 '&#1344;', 60 '&#1343;', 50 '&#1342;', 40 '&#1341;', 30 '&#1340;', 20 '&#1339;', 10 '&#1338;', 9 '&#1337;', 8 '&#1336;', 7 '&#1335;', 6 '&#1334;', 5 '&#1333;', 4 '&#1332;', 3 '&#1331;', 2 '&#1330;', 1 '&#1329;'; */
 }
 </bdo></code></div>
-<p class="note">All styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. </p>
+<p class="note">All styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.       Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">armenian</a></code>, <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">lower-armenian</a></code> and <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">upper-armenian</a></code> styles.</p>
 
 </section>
 
@@ -403,11 +479,11 @@ symbols: '\9E6' '\9E7' '\9E8' '\9E9' '\9EA' '\9EB' '\9EC' '\9ED' '\9EE' '\9EF';
 /* symbols: '&#2534;' '&#2535;' '&#2536;' '&#2537;' '&#2538;' '&#2539;' '&#2540;' '&#2541;' '&#2542;' '&#2543;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined  in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. </p>
+<p class="note">This style is defined  in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.     Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">bengali</a></code> style.</p>
 
 </section>
 <section id="cyrillic-styles">
-  <h2>Cyrillic</h2>
+<h2>Cyrillic</h2>
 
 <div class="counterstyle">
 <code><bdo dir="ltr">
@@ -585,7 +661,7 @@ symbols: '\915' '\916' '\917' '\918' '\919' '\91A' '\91B' '\91C' '\91D' '\91E' '
 /* symbols: '&#2325;' '&#2326;' '&#2327;' '&#2328;' '&#2329;' '&#2330;' '&#2331;' '&#2332;' '&#2333;' '&#2334;' '&#2335;' '&#2336;' '&#2337;' '&#2338;' '&#2339;' '&#2340;' '&#2341;' '&#2342;' '&#2343;' '&#2344;' '&#2346;' '&#2347;' '&#2348;' '&#2349;' '&#2350;' '&#2351;' '&#2352;' '&#2354;' '&#2357;' '&#2358;' '&#2359;' '&#2360;' '&#2361;'; */
 }
 </bdo></code></div>
-<p class="note">The <code class="kw" translate="no">devanagari</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification</p>
+<p class="note">The <code class="kw" translate="no">devanagari</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.     Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">devanagari</a></code> style.</p>
 </section>
 
 
@@ -813,7 +889,7 @@ suffix: '\1366 '; /* ፦ */
 }
 </bdo></code></div>
 
-<p class="note"> See also the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification for the more complex, predefined <code class="kw" translate="no">ethiopic-numeric</code> style.</p>
+<p class="note"> See also the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification for the more complex, predefined <code class="kw" translate="no">ethiopic-numeric</code> style.     Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#ethiopic" target="_blank">ethiopic-numeric</a></code> style.</p>
 </section>
 
 
@@ -830,7 +906,7 @@ additive-symbols: 10000 '\10F5', 9000 '\10F0', 8000 '\10EF', 7000 '\10F4', 6000 
 /* additive-symbols: 10000 '&#4341;', 9000 '&#4336;', 8000 '&#4335;', 7000 '&#4340;', 6000 '&#4334;', 5000 '&#4333;', 4000 '&#4332;', 3000 '&#4331;', 2000 '&#4330;', 1000 '&#4329;', 900 '&#4328;', 800 '&#4327;', 700 '&#4326;', 600 '&#4325;', 500 '&#4324;', 400 '&#4339;', 300 '&#4322;', 200 '&#4321;', 100 '&#4320;', 90 '&#4319;', 80 '&#4318;', 70 '&#4317;', 60 '&#4338;', 50 '&#4316;', 40 '&#4315;', 30 '&#4314;', 20 '&#4313;', 10 '&#4312;', 9 '&#4311;', 8 '&#4337;', 7 '&#4310;', 6 '&#4309;', 5 '&#4308;', 4 '&#4307;', 3 '&#4306;', 2 '&#4305;', 1 '&#4304;'; */
 }
 </bdo></code></div>
-<p class="note">This style is  defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. </p>
+<p class="note">This style is  defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.    Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">georgian</a></code> style.</p>
 
 </section>
 
@@ -884,7 +960,7 @@ symbols: '\3B1' '\3B2' '\3B3' '\3B4' '\3B5' '\3B6' '\3B7' '\3B8' '\3B9' '\3BA' '
 }
 </bdo></code></div>
 
-<p class="note">The <code class="kw" translate="no">lower-greek</code> style is  defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification, however the <code class="kw" translate="no">greek-lower-modern</code> style is more commonly used in Greece. CSS2.1 included the <code class="kw" translate="no">lower-greek</code> keyword, which <a href="https://github.com/w3c/csswg-drafts/issues/135#issuecomment-248303975">it appears</a> is used in mathematical texts, rather than ordinary Greek text. At the time of writing, all major browsers support the <code class="kw" translate="no">lower-greek</code> counter style but not the <code class="kw" translate="no">greek-lower-modern</code> style.</p>
+<p class="note">The <code class="kw" translate="no">lower-greek</code> style is  defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification, however the <code class="kw" translate="no">greek-lower-modern</code> style is more commonly used in Greece. CSS2.1 included the <code class="kw" translate="no">lower-greek</code> keyword, which <a href="https://github.com/w3c/csswg-drafts/issues/135#issuecomment-248303975">it appears</a> is used in mathematical texts, rather than ordinary Greek text. At the time of writing, all major browsers support the <code class="kw" translate="no">lower-greek</code> counter style but not the <code class="kw" translate="no">greek-lower-modern</code> style.  Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplealphabetic" target="_blank">lower-greek</a></code> style.</p>
 </section>
 
 
@@ -900,7 +976,7 @@ symbols: '\AE6' '\AE7' '\AE8' '\AE9' '\AEA' '\AEB' '\AEC' '\AED' '\AEE' '\AEF';
 /* symbols: '&#2790;' '&#2791;' '&#2792;' '&#2793;' '&#2794;' '&#2795;' '&#2796;' '&#2797;' '&#2798;' '&#2799;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. </p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.   Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">gujarati</a></code> style.</p>
 
 </section>
 
@@ -917,9 +993,33 @@ symbols: '\A66' '\A67' '\A68' '\A69' '\A6A' '\A6B' '\A6C' '\A6D' '\A6E' '\A6F';
 /* symbols: '&#2662;' '&#2663;' '&#2664;' '&#2665;' '&#2666;' '&#2667;' '&#2668;' '&#2669;' '&#2670;' '&#2671;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. </p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.   Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">gurmukhi</a></code> style.</p>
 
 </section>
+
+
+
+
+
+
+
+<section id="rohingya-styles">
+<h2>Hanifi Rohingya</h2>
+
+<div class="counterstyle">
+<code><bdo dir="ltr">
+@counter-style <dfn id="rohingya"><a href="#rohingya">hanifi-rohingya</a></dfn> {
+system: numeric;
+symbols: '\10D30' '\10D31' '\10D32' '\10D33' '\10D34' '\10D35' '\10D36' '\10D37' '\10D38' '\10D39';
+/* symbols: '&#x10D30;' '&#x10D31;' '&#x10D32;' '&#x10D33;' '&#x10D34;' '&#x10D35;' '&#x10D36;' '&#x10D37;' '&#x10D38;' '&#x10D39;'; */
+}
+</bdo></code></div>
+
+<p class="note">The style as described here uses a period+space (by default) as a suffix. Further investigation needs to be conducted to determine whether other affixes are common.</p>
+</section>
+
+
+
 
 
 
@@ -935,14 +1035,14 @@ additive-symbols: 10000 \5D9\5F3, 9000 \5D8\5F3, 8000 \5D7\5F3, 7000 \5D6\5F3, 6
 }</bdo>
 </code></div>
 <p class="note">This system manually specifies the values for 19-15 to force the correct display of 15 and 16, which are commonly rewritten to avoid a close resemblance to the Tetragrammaton. Predefined implementations may, and some do, choose to implement this manually to a higher range. (Users can define it how they like, of course.)</p>
-<p class="note">This style is  defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. </p>
+<p class="note">This style is  defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.  Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">hebrew</a></code> style.</p>
 
 </section>
 
 
 
 <section id="chinese-styles">
-  <h2> Han Ideographic (Chinese/Japanese/Korean)</h2>
+  <h2> Han CJK (Chinese/Japanese/Korean)</h2>
       
 <div class="counterstyle">
 <code><bdo dir="ltr">
@@ -979,61 +1079,6 @@ suffix: '\3001';
 }
 </bdo></code></div>
 
-<div class="counterstyle">
-<code><bdo dir="ltr">
-@counter-style <dfn id="japanese-informal"><a href="#japanese-informal">japanese-informal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
-system: additive;
-range: -9999 9999;
-additive-symbols: 9000 \4E5D\5343, 8000 \516B\5343, 7000 \4E03\5343, 6000 \516D\5343, 5000 \4E94\5343, 4000 \56DB\5343, 3000 \4E09\5343, 2000 \4E8C\5343, 1000 \5343, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4E94\767E, 400 \56DB\767E, 300 \4E09\767E, 200 \4E8C\767E, 100 \767E, 90 \4E5D\5341, 80 \516B\5341, 70 \4E03\5341, 60 \516D\5341, 50 \4E94\5341, 40 \56DB\5341, 30 \4E09\5341, 20 \4E8C\5341, 10 \5341, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4E94, 4 \56DB, 3 \4E09, 2 \4E8C, 1 \4E00, 0 \3007;
-/* additive-symbols: 9000 九千, 8000 八千, 7000 七千, 6000 六千, 5000 五千, 4000 四千, 3000 三千, 2000 二千, 1000 千, 900 九百, 800 八百, 700 七百, 600 六百, 500 五百, 400 四百, 300 三百, 200 二百, 100 百, 90 九十, 80 八十, 70 七十, 60 六十, 50 五十, 40 四十, 30 三十, 20 二十, 10 十, 9 九, 8 八, 7 七, 6 六, 5 五, 4 四, 3 三, 2 二, 1 一, 0 〇; */
-suffix: '\3001';
-/* suffix: '、'; */
-negative: "\30DE\30A4\30CA\30B9";
-/* negative: マイナス; */
-fallback: cjk-decimal;
-}
-</bdo></code></div>
-
-<div class="counterstyle">
-<code><bdo dir="ltr">
-@counter-style <dfn id="japanese-formal"><a href="#japanese-formal">japanese-formal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
-system: additive;
-range: -9999 9999;
-additive-symbols: 9000 \4E5D\9621, 8000 \516B\9621, 7000 \4E03\9621, 6000 \516D\9621, 5000 \4F0D\9621, 4000 \56DB\9621, 3000 \53C2\9621, 2000 \5F10\9621, 1000 \58F1\9621, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4F0D\767E, 400 \56DB\767E, 300 \53C2\767E, 200 \5F10\767E, 100 \58F1\767E, 90 \4E5D\62FE, 80 \516B\62FE, 70 \4E03\62FE, 60 \516D\62FE, 50 \4F0D\62FE, 40 \56DB\62FE, 30 \53C2\62FE, 20 \5F10\62FE, 10 \58F1\62FE, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4F0D, 4 \56DB, 3 \53C2, 2 \5F10, 1 \58F1, 0 \96F6;
-/* additive-symbols: 9000 九阡, 8000 八阡, 7000 七阡, 6000 六阡, 5000 伍阡, 4000 四阡, 3000 参阡, 2000 弐阡, 1000 壱阡, 900 九百, 800 八百, 700 七百, 600 六百, 500 伍百, 400 四百, 300 参百, 200 弐百, 100 壱百, 90 九拾, 80 八拾, 70 七拾, 60 六拾, 50 伍拾, 40 四拾, 30 参拾, 20 弐拾, 10 壱拾, 9 九, 8 八, 7 七, 6 六, 5 伍, 4 四, 3 参, 2 弐, 1 壱, 0 零; */
-suffix: '\3001';
-/* suffix: 、; */
-negative: "\30DE\30A4\30CA\30B9";
-/* negative: マイナス; */
-fallback: cjk-decimal;
-}
-</bdo></code></div>
-
-<div class="counterstyle">
-<code><bdo dir="ltr">
-@counter-style <dfn id="korean-hanja-informal"><a href="#korean-hanja-informal">korean-hanja-informal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
-system: additive;
-range: -9999 9999;
-additive-symbols: 9000 \4E5D\5343, 8000 \516B\5343, 7000 \4E03\5343, 6000 \516D\5343, 5000 \4E94\5343, 4000 \56DB\5343, 3000 \4E09\5343, 2000 \4E8C\5343, 1000 \5343, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4E94\767E, 400 \56DB\767E, 300 \4E09\767E, 200 \4E8C\767E, 100 \767E, 90 \4E5D\5341, 80 \516B\5341, 70 \4E03\5341, 60 \516D\5341, 50 \4E94\5341, 40 \56DB\5341, 30 \4E09\5341, 20 \4E8C\5341, 10 \5341, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4E94, 4 \56DB, 3 \4E09, 2 \4E8C, 1 \4E00, 0 \96F6;
-/* additive-symbols: 9000 九千, 8000 八千, 7000 七千, 6000 六千, 5000 五千, 4000 四千, 3000 三千, 2000 二千, 1000 千, 900 九百, 800 八百, 700 七百, 600 六百, 500 五百, 400 四百, 300 三百, 200 二百, 100 百, 90 九十, 80 八十, 70 七十, 60 六十, 50 五十, 40 四十, 30 三十, 20 二十, 10 十, 9 九, 8 八, 7 七, 6 六, 5 五, 4 四, 3 三, 2 二, 1 一, 0 零; */
-suffix:', ';
-negative: "\B9C8\C774\B108\C2A4  ";
-/* 마이너스 (followed by a space) */
-}
-</bdo></code></div>
-
-<div class="counterstyle">
-<code><bdo dir="ltr">
-@counter-style <dfn id="korean-hanja-formal"><a href="#korean-hanja-formal">korean-hanja-formal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
-system: additive;
-range: -9999 9999;
-additive-symbols: 9000 \4E5D\4EDF, 8000 \516B\4EDF, 7000 \4E03\4EDF, 6000 \516D\4EDF, 5000 \4E94\4EDF, 4000 \56DB\4EDF, 3000 \53C3\4EDF, 2000 \8CB3\4EDF, 1000 \58F9\4EDF, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4E94\767E, 400 \56DB\767E, 300 \53C3\767E, 200 \8CB3\767E, 100 \58F9\767E, 90 \4E5D\62FE, 80 \516B\62FE, 70 \4E03\62FE, 60 \516D\62FE, 50 \4E94\62FE, 40 \56DB\62FE, 30 \53C3\62FE, 20 \8CB3\62FE, 10 \58F9\62FE, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4E94, 4 \56DB, 3 \53C3, 2 \8CB3, 1 \58F9, 0 \96F6;
-/* additive-symbols: 9000 九仟, 8000 八仟, 7000 七仟, 6000 六仟, 5000 五仟, 4000 四仟, 3000 參仟, 2000 貳仟, 1000 壹仟, 900 九百, 800 八百, 700 七百, 600 六百, 500 五百, 400 四百, 300 參百, 200 貳百, 100 壹百, 90 九拾, 80 八拾, 70 七拾, 60 六拾, 50 五拾, 40 四拾, 30 參拾, 20 貳拾, 10 壹拾, 9 九, 8 八, 7 七, 6 六, 5 五, 4 四, 3 參, 2 貳, 1 壹, 0 零; */
-suffix:', ';
-negative: "\B9C8\C774\B108\C2A4  ";
-/* 마이너스 (followed by a space) */
-} 
-</bdo></code></div>
 <div class="counterstyle"> <code>
 <bdo dir="ltr">@counter-style <dfn id="circled-ideograph"><a href="#circled-ideograph">circled-ideograph</a></dfn> {
 system: fixed;
@@ -1078,8 +1123,8 @@ symbols:  '\7532\5B50' '\4E59\4E11' '\4E19\5BC5' '\4E01\536F' '\620A\8FB0' '\5DF
 suffix: '、';
 }</bdo>
 </code></div>
-<p class="note">The <code class="kw" translate="no">cjk-decimal</code>, <code class="kw" translate="no">cjk-earthly-branch</code>, <code class="kw" translate="no">cjk-heavenly-stem</code>, <code class="kw" translate="no">japanese-formal</code>, <code class="kw" translate="no">japanese-informal</code>, <code class="kw" translate="no">korean-hanja-formal</code>, and <code class="kw" translate="no">korean-hanja-informal</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. </p>
-<p class="note">Also, see the<code> </code>specification for the following more complex predefined Chinese styles: <code class="kw" translate="no">simp-chinese-informal</code>, <code class="kw" translate="no">simp-chinese-formal</code>, <code class="kw" translate="no">trad-chinese-informal</code>, <code class="kw" translate="no">trad-chinese-formal</code>, which are not defined here.</p>
+<p class="note">The <code class="kw" translate="no">cjk-decimal</code>, <code class="kw" translate="no">cjk-earthly-branch</code>, and <code class="kw" translate="no">cjk-heavenly-stem</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">cjk-decimal</a></code>, <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplefixed" target="_blank">cjk-earthly-branch</a></code>, and <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplefixed" target="_blank">cjk-heavenly-stem</a></code> styles.</p>
+<p class="note">Also, see the<code> </code>specification for the following more complex predefined Chinese styles: <code class="kw" translate="no">simp-chinese-informal</code>, <code class="kw" translate="no">simp-chinese-formal</code>, <code class="kw" translate="no">trad-chinese-informal</code>, <code class="kw" translate="no">trad-chinese-formal</code>, which are not defined here. Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#chinese" target="_blank">simp-chinese-informal</a></code>, <code><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#chinese" target="_blank">simp-chinese-formal</a></code>, <code><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#chinese" target="_blank">trad-chinese-informal</a></code>, and <code><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#chinese" target="_blank">trad-chinese-formal</a></code> styles.</p>
 </section>
 
 
@@ -1135,8 +1180,38 @@ suffix: ' ';
 } </bdo>
 </code></div>
 
-<p class="note">All styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
-<p class="note">See also the <a href="#chinese-styles">Ideographic</a> section for kanji styles.</p>
+<div class="counterstyle">
+<code><bdo dir="ltr">
+@counter-style <dfn id="japanese-informal"><a href="#japanese-informal">japanese-informal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
+system: additive;
+range: -9999 9999;
+additive-symbols: 9000 \4E5D\5343, 8000 \516B\5343, 7000 \4E03\5343, 6000 \516D\5343, 5000 \4E94\5343, 4000 \56DB\5343, 3000 \4E09\5343, 2000 \4E8C\5343, 1000 \5343, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4E94\767E, 400 \56DB\767E, 300 \4E09\767E, 200 \4E8C\767E, 100 \767E, 90 \4E5D\5341, 80 \516B\5341, 70 \4E03\5341, 60 \516D\5341, 50 \4E94\5341, 40 \56DB\5341, 30 \4E09\5341, 20 \4E8C\5341, 10 \5341, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4E94, 4 \56DB, 3 \4E09, 2 \4E8C, 1 \4E00, 0 \3007;
+/* additive-symbols: 9000 九千, 8000 八千, 7000 七千, 6000 六千, 5000 五千, 4000 四千, 3000 三千, 2000 二千, 1000 千, 900 九百, 800 八百, 700 七百, 600 六百, 500 五百, 400 四百, 300 三百, 200 二百, 100 百, 90 九十, 80 八十, 70 七十, 60 六十, 50 五十, 40 四十, 30 三十, 20 二十, 10 十, 9 九, 8 八, 7 七, 6 六, 5 五, 4 四, 3 三, 2 二, 1 一, 0 〇; */
+suffix: '\3001';
+/* suffix: '、'; */
+negative: "\30DE\30A4\30CA\30B9";
+/* negative: マイナス; */
+fallback: cjk-decimal;
+}
+</bdo></code></div>
+
+<div class="counterstyle">
+<code><bdo dir="ltr">
+@counter-style <dfn id="japanese-formal"><a href="#japanese-formal">japanese-formal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
+system: additive;
+range: -9999 9999;
+additive-symbols: 9000 \4E5D\9621, 8000 \516B\9621, 7000 \4E03\9621, 6000 \516D\9621, 5000 \4F0D\9621, 4000 \56DB\9621, 3000 \53C2\9621, 2000 \5F10\9621, 1000 \58F1\9621, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4F0D\767E, 400 \56DB\767E, 300 \53C2\767E, 200 \5F10\767E, 100 \58F1\767E, 90 \4E5D\62FE, 80 \516B\62FE, 70 \4E03\62FE, 60 \516D\62FE, 50 \4F0D\62FE, 40 \56DB\62FE, 30 \53C2\62FE, 20 \5F10\62FE, 10 \58F1\62FE, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4F0D, 4 \56DB, 3 \53C2, 2 \5F10, 1 \58F1, 0 \96F6;
+/* additive-symbols: 9000 九阡, 8000 八阡, 7000 七阡, 6000 六阡, 5000 伍阡, 4000 四阡, 3000 参阡, 2000 弐阡, 1000 壱阡, 900 九百, 800 八百, 700 七百, 600 六百, 500 伍百, 400 四百, 300 参百, 200 弐百, 100 壱百, 90 九拾, 80 八拾, 70 七拾, 60 六拾, 50 伍拾, 40 四拾, 30 参拾, 20 弐拾, 10 壱拾, 9 九, 8 八, 7 七, 6 六, 5 伍, 4 四, 3 参, 2 弐, 1 壱, 0 零; */
+suffix: '\3001';
+/* suffix: 、; */
+negative: "\30DE\30A4\30CA\30B9";
+/* negative: マイナス; */
+fallback: cjk-decimal;
+}
+</bdo></code></div>
+
+<p class="note">All styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.    Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplealphabetic" target="_blank">hiragana</a>, <a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplealphabetic" target="_blank">hiragana-iroha</a>, <a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplealphabetic" target="_blank">katakana</a>, <a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplealphabetic" target="_blank">katakana-iroha</a>, <a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#japanese" target="_blank">japanese-informal</a></code> and <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#japanese" target="_blank">japanese-formal</a></code> styles.</p>
+<p class="note">See also the <a href="#chinese-styles">Han CJK</a> section for additional styles.</p>
 </section>
 
 
@@ -1152,7 +1227,7 @@ symbols: '\CE6' '\CE7' '\CE8' '\CE9' '\CEA' '\CEB' '\CEC' '\CED' '\CEE' '\CEF';
 /* symbols: '&#3302;' '&#3303;' '&#3304;' '&#3305;' '&#3306;' '&#3307;' '&#3308;' '&#3309;' '&#3310;' '&#3311;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">kannada</a></code> style.</p>
 
 </section>
 
@@ -1190,7 +1265,7 @@ symbols: '\1780' '\1781' '\1782' '\1783' '\1784' '\1785' '\1786' '\1787' '\1788'
 </bdo></code></div>
 
 <p class="note">The <code class="kw" translate="no">cambodian</code> and <code class="kw" translate="no">khmer</code> styles are exactly the same. Both are listed separately here because both names are supported in some browsers, and it makes it easier to cut and paste if two clean instances are provided.</p>
-<p class="note">The <code class="kw" translate="no">cambodian</code> and <code class="kw" translate="no">khmer</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">The <code class="kw" translate="no">cambodian</code> and <code class="kw" translate="no">khmer</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.   Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">cambodian</a></code> and <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">khmer</a></code> styles.</p>
 
 </section>
 
@@ -1268,11 +1343,36 @@ symbols: '\320E' '\320F' '\3210' '\3211' '\3212' '\3213' '\3214' '\3215' '\3216'
 /* symbols: '&#12814;' '&#12815;' '&#12816;' '&#12817;' '&#12818;' '&#12819;' '&#12820;' '&#12821;' '&#12822;' '&#12823;' '&#12824;' '&#12825;' '&#12826;'; */
 suffix: ' ';
 }
-</bdo></code>
-<p>See also the <a href="#chinese-styles">Ideographic</a> section for hanja styles.</p>
-</div>
-<p class="note">The <code class="kw" translate="no">korean-hangul-formal</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+</bdo></code></div>
 
+
+<div class="counterstyle">
+<code><bdo dir="ltr">
+@counter-style <dfn id="korean-hanja-informal"><a href="#korean-hanja-informal">korean-hanja-informal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
+system: additive;
+range: -9999 9999;
+additive-symbols: 9000 \4E5D\5343, 8000 \516B\5343, 7000 \4E03\5343, 6000 \516D\5343, 5000 \4E94\5343, 4000 \56DB\5343, 3000 \4E09\5343, 2000 \4E8C\5343, 1000 \5343, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4E94\767E, 400 \56DB\767E, 300 \4E09\767E, 200 \4E8C\767E, 100 \767E, 90 \4E5D\5341, 80 \516B\5341, 70 \4E03\5341, 60 \516D\5341, 50 \4E94\5341, 40 \56DB\5341, 30 \4E09\5341, 20 \4E8C\5341, 10 \5341, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4E94, 4 \56DB, 3 \4E09, 2 \4E8C, 1 \4E00, 0 \96F6;
+/* additive-symbols: 9000 九千, 8000 八千, 7000 七千, 6000 六千, 5000 五千, 4000 四千, 3000 三千, 2000 二千, 1000 千, 900 九百, 800 八百, 700 七百, 600 六百, 500 五百, 400 四百, 300 三百, 200 二百, 100 百, 90 九十, 80 八十, 70 七十, 60 六十, 50 五十, 40 四十, 30 三十, 20 二十, 10 十, 9 九, 8 八, 7 七, 6 六, 5 五, 4 四, 3 三, 2 二, 1 一, 0 零; */
+suffix:', ';
+negative: "\B9C8\C774\B108\C2A4  ";
+/* 마이너스 (followed by a space) */
+}
+</bdo></code></div>
+
+<div class="counterstyle">
+<code><bdo dir="ltr">
+@counter-style <dfn id="korean-hanja-formal"><a href="#korean-hanja-formal">korean-hanja-formal</a></dfn> { /* this is a predefined complex style in the <a href="https://www.w3.org/TR/css-counter-styles-3/#complex-predefined-counters">CSS3 Counter Styles</a> specification */
+system: additive;
+range: -9999 9999;
+additive-symbols: 9000 \4E5D\4EDF, 8000 \516B\4EDF, 7000 \4E03\4EDF, 6000 \516D\4EDF, 5000 \4E94\4EDF, 4000 \56DB\4EDF, 3000 \53C3\4EDF, 2000 \8CB3\4EDF, 1000 \58F9\4EDF, 900 \4E5D\767E, 800 \516B\767E, 700 \4E03\767E, 600 \516D\767E, 500 \4E94\767E, 400 \56DB\767E, 300 \53C3\767E, 200 \8CB3\767E, 100 \58F9\767E, 90 \4E5D\62FE, 80 \516B\62FE, 70 \4E03\62FE, 60 \516D\62FE, 50 \4E94\62FE, 40 \56DB\62FE, 30 \53C3\62FE, 20 \8CB3\62FE, 10 \58F9\62FE, 9 \4E5D, 8 \516B, 7 \4E03, 6 \516D, 5 \4E94, 4 \56DB, 3 \53C3, 2 \8CB3, 1 \58F9, 0 \96F6;
+/* additive-symbols: 9000 九仟, 8000 八仟, 7000 七仟, 6000 六仟, 5000 五仟, 4000 四仟, 3000 參仟, 2000 貳仟, 1000 壹仟, 900 九百, 800 八百, 700 七百, 600 六百, 500 五百, 400 四百, 300 參百, 200 貳百, 100 壹百, 90 九拾, 80 八拾, 70 七拾, 60 六拾, 50 五拾, 40 四拾, 30 參拾, 20 貳拾, 10 壹拾, 9 九, 8 八, 7 七, 6 六, 5 五, 4 四, 3 參, 2 貳, 1 壹, 0 零; */
+suffix:', ';
+negative: "\B9C8\C774\B108\C2A4  ";
+/* 마이너스 (followed by a space) */
+} 
+</bdo></code></div>
+<p class="note">The <code class="kw" translate="no">korean-hangul-formal</code>, <code class="kw" translate="no">korean-hanja-formal</code>, and <code class="kw" translate="no">korean-hanja-informal</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.  Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#korean" target="_blank">korean-hangul-formal</a></code>, <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#korean" target="_blank">korean-hanja-formal</a></code> and <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#korean" target="_blank">korean-hanja-informal</a></code> styles.</p>
+<p class="note">See also the <a href="#chinese-styles">Han CJK</a> section for additional styles.</p>
 </section>
 
 
@@ -1288,7 +1388,7 @@ symbols: '\ED0' '\ED1' '\ED2' '\ED3' '\ED4' '\ED5' '\ED6' '\ED7' '\ED8' '\ED9';
 /* symbols: '&#3792;' '&#3793;' '&#3794;' '&#3795;' '&#3796;' '&#3797;' '&#3798;' '&#3799;' '&#3800;' '&#3801;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">lao</a></code> style.</p>
 
 </section>
 
@@ -1414,7 +1514,7 @@ symbols: '\D66' '\D67' '\D68' '\D69' '\D6A' '\D6B' '\D6C' '\D6D' '\D6E' '\D6F';
 /* symbols: '&#3430;' '&#3431;' '&#3432;' '&#3433;' '&#3434;' '&#3435;' '&#3436;' '&#3437;' '&#3438;' '&#3439;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">malayalam</a></code> style.</p>
 
 </section>
 
@@ -1448,7 +1548,7 @@ symbols: '\1810' '\1811' '\1812' '\1813' '\1814' '\1815' '\1816' '\1817' '\1818'
 /* symbols: '&#6160;' '&#6161;' '&#6162;' '&#6163;' '&#6164;' '&#6165;' '&#6166;' '&#6167;' '&#6168;' '&#6169;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">mongolian</a></code> style.</p>
 
 </section>
 
@@ -1463,6 +1563,8 @@ symbols: '\1810' '\1811' '\1812' '\1813' '\1814' '\1815' '\1816' '\1817' '\1818'
 system: numeric;
 symbols: '\1040' '\1041' '\1042' '\1043' '\1044' '\1045' '\1046' '\1047' '\1048' '\1049';
 /* symbols: '&#4160;' '&#4161;' '&#4162;' '&#4163;' '&#4164;' '&#4165;' '&#4166;' '&#4167;' '&#4168;' '&#4169;'; */
+prefix: '('
+suffix: ') '; 
 }
 </bdo></code></div>
 
@@ -1472,9 +1574,23 @@ symbols: '\1040' '\1041' '\1042' '\1043' '\1044' '\1045' '\1046' '\1047' '\1048'
 system: numeric;
 symbols: '\1090' '\1091' '\1092' '\1093' '\1094' '\1095' '\1096' '\1097' '\1098' '\1099';
 /* symbols: '&#4240;' '&#4241;' '&#4242;' '&#4243;' '&#4244;' '&#4245;' '&#4246;' '&#4247;' '&#4248;' '&#4249;'; */
+prefix: '('
+suffix: ') '; 
 }
-</bdo></code></div>
-<p class="note">The <code class="kw" translate="no">myanmar</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+</bdo></code>
+</div>
+
+
+<p class="note"><strong>Alternative prefix/suffix styles:</strong> When supported by browsers natively, the <code class="kw" translate="no">myanmar</code> counters are followed by period+space, however it is more common for counters in lists to appear in parentheses, as shown here. Both <code class="kw" translate="no">myanmar</code> and <code class="kw" translate="no">shan</code> styles may also sometimes use <span class="codepoint" translate="no"><span lang="my">&#x104B;</span> [<span class="uname">U+104B MYANMAR SIGN SECTION</span>]</span> as a suffix, instead of surrounding the counter with parentheses. The replacement code for that is:<br>
+<code><bdo dir="ltr">
+prefix: '';<br>
+suffix: \104B\0020; /*။ */
+</bdo>
+</code>
+</p>
+
+
+<p class="note">The <code class="kw" translate="no">myanmar</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification, but with period+space as the default suffix (see just above). Check  browser  support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">myanmar</a></code> style.</p>
 
 </section>
 
@@ -1495,7 +1611,7 @@ symbols: '\1C50' '\1C51' '\1C52' '\1C53' '\1C54' '\1C55' '\1C56' '\1C57' '\1C58'
 }
 </bdo></code>
 
-<code>
+<!--code>
 Alternative prefix/suffix styles:
 
 <bdo dir="ltr">/* space only */
@@ -1505,7 +1621,11 @@ suffix: ' ';
 prefix: '('
 suffix: ') '; 
 </bdo>
-</code></div>
+</code--></div>
+
+
+
+<p class="note"><strong>Alternative prefix/suffix styles:</strong> The <code class="kw" translate="no">santali</code> style described here produces a period+space suffix, however  counters are sometimes followed by just a space, or enclosed in parentheses.</p>
 </section>
 
 
@@ -1523,7 +1643,7 @@ symbols: '\B66' '\B67' '\B68' '\B69' '\B6A' '\B6B' '\B6C' '\B6D' '\B6E' '\B6F';
 /* symbols: '&#2918;' '&#2919;' '&#2920;' '&#2921;' '&#2922;' '&#2923;' '&#2924;' '&#2925;' '&#2926;' '&#2927;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">oriya</a></code> style.</p>
 
 </section>
 
@@ -1550,7 +1670,7 @@ symbols: '\BE6' '\BE7' '\BE8' '\BE9' '\BEA' '\BEB' '\BEC' '\BED' '\BEE' '\BEF';
 /* symbols: '&#3046;' '&#3047;' '&#3048;' '&#3049;' '&#3050;' '&#3051;' '&#3052;' '&#3053;' '&#3054;' '&#3055;'; */
 }
 </bdo></code></div>
-<p class="note">The <code class="kw" translate="no">tamil</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">The <code class="kw" translate="no">tamil</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">tamil</a></code> style.</p>
 
 </section>
 
@@ -1567,7 +1687,7 @@ symbols: '\C66' '\C67' '\C68' '\C69' '\C6A' '\C6B' '\C6C' '\C6D' '\C6E' '\C6F';
 /* symbols: '&#3174;' '&#3175;' '&#3176;' '&#3177;' '&#3178;' '&#3179;' '&#3180;' '&#3181;' '&#3182;' '&#3183;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">telugu</a></code> style.</p>
 
 </section>
 
@@ -1593,7 +1713,7 @@ symbols: '\E01' '\E02' '\E04' '\E07' '\E08' '\E09' '\E0A' '\E0B' '\E0C' '\E0D' '
 /* symbols: '&#3585;' '&#3586;' '&#3588;' '&#3591;' '&#3592;' '&#3593;' '&#3594;' '&#3595;' '&#3596;' '&#3597;' '&#3598;' '&#3599;' '&#3600;' '&#3601;' '&#3602;' '&#3603;' '&#3604;' '&#3605;' '&#3606;' '&#3607;' '&#3608;' '&#3609;' '&#3610;' '&#3611;' '&#3612;' '&#3613;' '&#3614;' '&#3615;' '&#3616;' '&#3617;' '&#3618;' '&#3619;' '&#3621;' '&#3623;' '&#3624;' '&#3625;' '&#3626;' '&#3627;' '&#3628;' '&#3629;' '&#3630;'; */
 }
 </bdo></code></div>
-<p class="note">The <code class="kw" translate="no">thai</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">The <code class="kw" translate="no">thai</code> style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">thai</a></code> style.</p>
 
 </section>
 
@@ -1610,7 +1730,7 @@ symbols: '\F20' '\F21' '\F22' '\F23' '\F24' '\F25' '\F26' '\F27' '\F28' '\F29';
 /* symbols: '&#3872;' '&#3873;' '&#3874;' '&#3875;' '&#3876;' '&#3877;' '&#3878;' '&#3879;' '&#3880;' '&#3881;'; */
 }
 </bdo></code></div>
-<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">This style is defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for the <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">tibetan</a></code> style.</p>
 
 </section>
 
@@ -1846,7 +1966,7 @@ additive-symbols: 1000 '\4D', 900 '\43\4D', 500 '\44', 400 '\43\44', 100 '\43', 
 /* additive-symbols: 1000 'M', 900 'CM', 500 'D', 400 'CD', 100 'C', 90 'XC', 50 'L', 40 'XL', 10 'X', 9 'IX', 5 'V', 4 'IV', 1 'I'; */
 }
 </bdo></code></div>
-<p class="note">The <code class="kw" translate="no">lower-roman</code>  and <code class="kw" translate="no">upper-roman</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification.</p>
+<p class="note">The <code class="kw" translate="no">lower-roman</code>  and <code class="kw" translate="no">upper-roman</code> styles are defined in the <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a> specification. Check browser support for  <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">lower-roman</a></code> and <code class="kw" translate="no"><a href="https://www.w3.org/International/i18n-tests/results/predefined-counter-styles#simplenumeric" target="_blank">upper-roman</a></code> styles.</p>
 
 </section>
 
@@ -1856,10 +1976,10 @@ additive-symbols: 1000 '\4D', 900 '\43\4D', 500 '\44', 400 '\43\44', 100 '\43', 
 
 
 <section class="appendix" id="app-b">
-  <h2>References</h2>
+<h2>References</h2>
 <dl>
   <dt id="css3list" title="CSS3LIST">[COUNTERS]</dt>
-  <dd>Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a>.   3 February 2015. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/css-counter-styles-3/">https://www.w3.org/TR/css-counter-styles-3/</a></dd>
+  <dd>Tab Atkins Jr. <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a>.   3 February 2015. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/css-counter-styles-3/">https://www.w3.org/TR/css-counter-styles-3/</a></dd>
   </dl>
   </section>
 
@@ -1867,9 +1987,14 @@ additive-symbols: 1000 '\4D', 900 '\43\4D', 500 '\44', 400 '\43\44', 100 '\43', 
   <h2> Revision Log</h2>
   <p>The following summarises substantive changes since the previous publication.</p>
   <ol>
-    <li>Added <code class="kw" translate="no">cjk-tally-mark</code> and <code class="kw" translate="no">cjk-stem-branch</code></li>
+    <li>Add <code class="kw" translate="no">cjk-tally-mark</code> and <code class="kw" translate="no">cjk-stem-branch</code></li>
 <li>Change <code class="kw" translate="no">cjk-earthly-branch</code> and <code class="kw" translate="no">cjk-heavenly-stem</code> from <code class="kw" translate="no">alphabetic</code> to <code class="kw" translate="no">fixed</code></li>
-<li>Added <code class="kw" translate="no">meetei</code></li>
+<li>Add new section <a href="#affixes">1.1 Adapting prefixes &amp; suffixes</a>.</li>
+<li>Add <code class="kw" translate="no">adlam</code>, <code class="kw" translate="no">hanifi-rohingya</code>, <code class="kw" translate="no">lepcha</code>, <code class="kw" translate="no">meetei</code>, and <code class="kw" translate="no">santali</code> styles.</li>
+<li>Change the default affixes for <code class="kw" translate="no">myanmar</code> and <code class="kw" translate="no">shan</code> to parentheses, and add myanmar sign section as an alternative.</li>
+<li>Add links to test results for styles defined in the Counter Styles spec.</li>
+<li>Move Japanese and Korean ideographic styles from the Han section into the respective language sections.</li>
+<li>Add some initial information about alternative prefix/suffix styles.</li>
 </ol>
     <p>See the <a href="https://github.com/w3c/predefined-counter-styles/commits/gh-pages">github commit log</a> for more details.</p>
 </section>


### PR DESCRIPTION
Add new section 1.1 Adapting prefixes & suffixes.
Add adlam, hanifi-rohingya, lepcha, meetei, and santali styles.
Change the default affixes for myanmar and shan to parentheses, and add myanmar sign section as an alternative.
Add links to test results for styles defined in the Counter Styles spec.
Move Japanese and Korean ideographic styles from the Han section into the respective language sections.
Add some initial information about alternative prefix/suffix styles.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/predefined-counter-styles/pull/38.html" title="Last updated on Jun 4, 2021, 3:16 PM UTC (0bba3b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/predefined-counter-styles/38/12c57e7...0bba3b3.html" title="Last updated on Jun 4, 2021, 3:16 PM UTC (0bba3b3)">Diff</a>