### PR TITLE
Fix haleme typo, it should be halehame

### DIFF
--- a/index.html
+++ b/index.html
@@ -960,7 +960,7 @@ suffix: '\1366 '; /* ፦ */
 
 <div class="counterstyle">
 <code><bdo dir="ltr">
-@counter-style <dfn id="ethiopic-haleme"><a href="#ethiopic-haleme">ethiopic-haleme</a></dfn> {
+@counter-style <dfn id="ethiopic-halehame"><a href="#ethiopic-halehame">ethiopic-halehame</a></dfn> {
 system: alphabetic;
 symbols: '\1200' '\1208' '\1210' '\1218' '\1220' '\1228' '\1230' '\1240' '\1260' '\1270' '\1280' '\1290' '\12A0' '\12A8' '\12C8' '\12D0' '\12D8' '\12E8' '\12F0' '\1308' '\1320' '\1330' '\1338' '\1340' '\1348' '\1350';
 /* symbols: '&#x1200;' '&#x1208;' '&#x1210;' '&#x1218;' '&#x1220;' '&#x1228;' '&#x1230;' '&#x1240;' '&#x1260;' '&#x1270;' '&#x1280;' '&#x1290;' '&#x12A0;' '&#x12A8;' '&#x12C8;' '&#x12D0;' '&#x12D8;' '&#x12E8;' '&#x12F0;' '&#x1308;' '&#x1320;' '&#x1330;' '&#x1338;' '&#x1340;' '&#x1348;' '&#x1350;'; */
@@ -970,7 +970,7 @@ suffix: '\1366 '; /* ፦ */
 
 <div class="counterstyle">
 <code><bdo dir="ltr">
-@counter-style <dfn id="ethiopic-haleme-am"><a href="#ethiopic-haleme-am">ethiopic-haleme-am</a></dfn> {
+@counter-style <dfn id="ethiopic-halehame-am"><a href="#ethiopic-halehame-am">ethiopic-halehame-am</a></dfn> {
 system: alphabetic;
 symbols: '\1200' '\1208' '\1210' '\1218' '\1220' '\1228' '\1230' '\1238' '\1240' '\1260' '\1270' '\1278' '\1280' '\1290' '\1298' '\12A0' '\12A8' '\12B8' '\12C8' '\12D0' '\12D8' '\12E0' '\12E8' '\12F0' '\1300' '\1308' '\1320' '\1328' '\1330' '\1338' '\1340' '\1348' '\1350';
 /* symbols: '&#x1200;' '&#x1208;' '&#x1210;' '&#x1218;' '&#x1220;' '&#x1228;' '&#x1230;' '&#x1238;' '&#x1240;' '&#x1260;' '&#x1270;' '&#x1278;' '&#x1280;' '&#x1290;' '&#x1298;' '&#x12A0;' '&#x12A8;' '&#x12B8;' '&#x12C8;' '&#x12D0;' '&#x12D8;' '&#x12E0;' '&#x12E8;' '&#x12F0;' '&#x1300;' '&#x1308;' '&#x1320;' '&#x1328;' '&#x1330;' '&#x1338;' '&#x1340;' '&#x1348;' '&#x1350;'; */
@@ -980,7 +980,7 @@ suffix: '\1366 '; /* ፦ */
 
 <div class="counterstyle">
 <code><bdo dir="ltr">
-@counter-style <dfn id="ethiopic-haleme-ti-er"><a href="#ethiopic-haleme-ti-er">ethiopic-haleme-ti-er</a></dfn> {
+@counter-style <dfn id="ethiopic-halehame-ti-er"><a href="#ethiopic-halehame-ti-er">ethiopic-halehame-ti-er</a></dfn> {
 system: alphabetic;
 symbols: '\1200' '\1208' '\1210' '\1218' '\1228' '\1230' '\1238' '\1240' '\1250' '\1260' '\1270' '\1278' '\1290' '\1298' '\12A0' '\12A8' '\12B8' '\12C8' '\12D0' '\12D8' '\12E0' '\12E8' '\12F0' '\1300' '\1308' '\1320' '\1328' '\1330' '\1338' '\1348' '\1350';
 /* symbols: '&#x1200;' '&#x1208;' '&#x1210;' '&#x1218;' '&#x1228;' '&#x1230;' '&#x1238;' '&#x1240;' '&#x1250;' '&#x1260;' '&#x1270;' '&#x1278;' '&#x1290;' '&#x1298;' '&#x12A0;' '&#x12A8;' '&#x12B8;' '&#x12C8;' '&#x12D0;' '&#x12D8;' '&#x12E0;' '&#x12E8;' '&#x12F0;' '&#x1300;' '&#x1308;' '&#x1320;' '&#x1328;' '&#x1330;' '&#x1338;' '&#x1348;' '&#x1350;'; */
@@ -990,7 +990,7 @@ suffix: '\1366 '; /* ፦ */
 
 <div class="counterstyle">
 <code><bdo dir="ltr">
-@counter-style <dfn id="ethiopic-haleme-ti-et"><a href="#ethiopic-haleme-ti-et">ethiopic-haleme-ti-et</a></dfn> {
+@counter-style <dfn id="ethiopic-halehame-ti-et"><a href="#ethiopic-halehame-ti-et">ethiopic-halehame-ti-et</a></dfn> {
 system: alphabetic;
 symbols: '\1200' '\1208' '\1210' '\1218' '\1220' '\1228' '\1230' '\1238' '\1240' '\1250' '\1260' '\1270' '\1278' '\1280' '\1290' '\1298' '\12A0' '\12A8' '\12B8' '\12C8' '\12D0' '\12D8' '\12E0' '\12E8' '\12F0' '\1300' '\1308' '\1320' '\1328' '\1330' '\1338' '\1340' '\1348' '\1350';
 /* symbols: '&#x1200;' '&#x1208;' '&#x1210;' '&#x1218;' '&#x1220;' '&#x1228;' '&#x1230;' '&#x1238;' '&#x1240;' '&#x1250;' '&#x1260;' '&#x1270;' '&#x1278;' '&#x1280;' '&#x1290;' '&#x1298;' '&#x12A0;' '&#x12A8;' '&#x12B8;' '&#x12C8;' '&#x12D0;' '&#x12D8;' '&#x12E0;' '&#x12E8;' '&#x12F0;' '&#x1300;' '&#x1308;' '&#x1320;' '&#x1328;' '&#x1330;' '&#x1338;' '&#x1340;' '&#x1348;' '&#x1350;'; */


### PR DESCRIPTION
After some research done online, it seems like "haleme" is a typo, and it should actually be halehame.

See https://github.com/WebKit/WebKit/pull/13323#discussion_r1182536088


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nt1m/predefined-counter-styles/pull/56.html" title="Last updated on May 3, 2023, 4:21 AM UTC (4b5268d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/predefined-counter-styles/56/001051b...nt1m:4b5268d.html" title="Last updated on May 3, 2023, 4:21 AM UTC (4b5268d)">Diff</a>