### PR TITLE
Change Symbola to LXGW WenKai

### DIFF
--- a/index.html
+++ b/index.html
@@ -4104,7 +4104,7 @@ suffix: ' ';
 
 
 <aside class="note">
-<p>These symbols were introduced in Unicode 11, so not many fonts are likely to support them. One font that does is Symbola.</p>
+<p>These symbols were introduced in Unicode 11, so not many fonts are likely to support them. One font that does is LXGW WenKai (<span lang="zh-hans">霞鹜文楷</span>).</p>
 </aside>
 
 


### PR DESCRIPTION
I tried to search Symbola and downloaded several versions of this font, but found that none of them support these symbols. Maybe the versions I downloaded were too old.

I found another font that supports these symbols, and it's a popular open-source font: [LXGW WenKai](https://github.com/lxgw/LxgwWenKai).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/predefined-counter-styles/pull/62.html" title="Last updated on Sep 5, 2023, 6:48 AM UTC (2ff1c8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/predefined-counter-styles/62/4c0e087...2ff1c8e.html" title="Last updated on Sep 5, 2023, 6:48 AM UTC (2ff1c8e)">Diff</a>